### PR TITLE
Remove redundant version declaration from Docker Compose file

### DIFF
--- a/lightrag-ollama-stack/docker-compose.yml
+++ b/lightrag-ollama-stack/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ollama:
     image: ollama/ollama:latest


### PR DESCRIPTION
## Summary
- remove the legacy version declaration so the compose file begins directly with the services block

## Testing
- docker compose up -d *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c90258d083258efbeca659a3f8f1