### PR TITLE
Enable GPU configuration for Ollama service

### DIFF
--- a/lightrag-ollama-stack/docker-compose.yml
+++ b/lightrag-ollama-stack/docker-compose.yml
@@ -6,6 +6,17 @@ services:
     ports: ["11434:11434"]
     volumes:
       - ollama_models:/root/.ollama
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: ["gpu"]
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
       interval: 10s


### PR DESCRIPTION
## Summary
- configure the Ollama service to use the NVIDIA runtime and expose GPU resources
- set environment variables so all GPUs and required driver capabilities are available inside the container
- reserve an NVIDIA GPU device via the compose deploy resources block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d8552f748325960494d9f42db104